### PR TITLE
Fix paul grahams order

### DIFF
--- a/scripts/data/synthetic/json/download_paulgraham_essay.py
+++ b/scripts/data/synthetic/json/download_paulgraham_essay.py
@@ -64,8 +64,8 @@ for url in tqdm(urls):
         except Exception as e:
             print(f"Fail download {filename}, ({e})")
 
-files_repo = glob.glob(os.path.join(temp_folder_repo,'*.txt'))
-files_html = glob.glob(os.path.join(temp_folder_html,'*.txt'))
+files_repo = sorted(glob.glob(os.path.join(temp_folder_repo,'*.txt')))
+files_html = sorted(glob.glob(os.path.join(temp_folder_html,'*.txt')))
 print(f'Download {len(files_repo)} essays from `https://github.com/gkamradt/LLMTest_NeedleInAHaystack/`') 
 print(f'Download {len(files_html)} essays from `http://www.paulgraham.com/`') 
 


### PR DESCRIPTION
The original paul grahams essay dataset concatenate implementation uses `glob.glob` to list all files, which is not order-preserving, could lead to different dataset files on different machine or even differen directories.
This fix uses `sorted` here to make sure the dataset file remains the same in different environments.