### PR TITLE
Restore answer_prefix in standalone prediction path

### DIFF
--- a/scripts/pred/call_api.py
+++ b/scripts/pred/call_api.py
@@ -302,7 +302,7 @@ def main():
                 kwargs=dict(
                     idx_list=idx_list,
                     index_list=[data_point['index'] for data_point in batch],
-                    input_list=[data_point['input'] for data_point in batch],
+                    input_list=[data_point['input'] + data_point.get('answer_prefix', '') for data_point in batch],
                     outputs_list=[data_point['outputs'] for data_point in batch],
                     others_list=[data_point.get('others', {}) for data_point in batch],
                     truncation_list=[data_point.get('truncation', -1) for data_point in batch],


### PR DESCRIPTION
## Summary

Re-attach the task's `answer_prefix` when constructing request prompts in
the standalone `call_api.py` path.

The January 2025 data-generation refactor stores this suffix separately,
but `call_api.py` currently sends only `data_point['input']`. Using
`.get('answer_prefix', '')` preserves compatibility with older JSONL files.

Both `batch_size=1` and larger batches pass through this same construction
path.

Fixes #107